### PR TITLE
Preventing side effect of merge Function

### DIFF
--- a/JavaScript/d-decompose.js
+++ b/JavaScript/d-decompose.js
@@ -5,7 +5,7 @@ const merge = (
   ...args // array of array
   // Returns: array
 ) => {
-  const array = args[0];
+  const array = [...args[0]];
   for (let i = 1; i < args.length; i++) {
     const arr = args[i];
     for (let j = 0; j < arr.length; j++) {


### PR DESCRIPTION
Now merge returns clearly new Array, instead of modificated args[0]